### PR TITLE
chore: update snap license and name

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 env:
-  SNAP_AMD64: real-time-tests_${{ github.run_number}}_amd64.snap
+  SNAP_AMD64: rt-tests_${{ github.run_number}}_amd64.snap
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This is the snap packaging of
 To install it:
 
 ```bash
-sudo snap install real-time-tests
+sudo snap install rt-tests
 ```
 
 ## Configure
@@ -23,7 +23,7 @@ sudo snap install real-time-tests
 It's necessary to connect the [process-control](https://snapcraft.io/docs/process-control-interface) interface to work properly:
 
 ```bash
-sudo snap connect real-time-tests:process-control :process-control
+sudo snap connect rt-tests:process-control :process-control
 ```
 
 ### Local Build

--- a/README.md
+++ b/README.md
@@ -3,9 +3,7 @@
 
 [![real-time-tests](https://snapcraft.io/real-time-tests/badge.svg)](https://snapcraft.io/real-time-tests)
 
-[![Get it from the Snap Store](https://snapcraft.io/static/images/badges/en/snap-store-black.svg)](https://snapcraft.io/real-time-tests)
-
-This is the snap packaging of
+This is the snap packaging o
 [rt-tests](https://wiki.linuxfoundation.org/realtime/documentation/howto/tools/rt-tests).
 
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 
 # Real Time Tests Snap 
 
-[![real-time-tests](https://snapcraft.io/real-time-tests/badge.svg)](https://snapcraft.io/real-time-tests)
+[![rt-tests](https://snapcraft.io/rt-tests/badge.svg)](https://snapcraft.io/rt-tests)
 
-This is the snap packaging o
+[![Get it from the Snap Store](https://snapcraft.io/static/images/badges/en/snap-store-black.svg)](https://snapcraft.io/rt-tests)
+
+This is the snap packaging of
 [rt-tests](https://wiki.linuxfoundation.org/realtime/documentation/howto/tools/rt-tests).
 
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,4 +1,4 @@
-name: real-time-tests 
+name: rt-tests
 base: core24
 version: nil
 summary: Real time tests for UC24
@@ -9,7 +9,7 @@ description: |
   cyclictest, deadline_test, hackbench, oslat, pi_stress, pip_stress, pmqtest,
   ptsematest, queuelat, rt-migrate-test, signaltest, sigwaittest, ssdd, svsematest.
 
-license: GPL-2.0
+license: GPL-2.0-or-later AND LGPL-2.1-or-later
 grade: stable
 confinement: strict
 adopt-info: rt-tests


### PR DESCRIPTION
- Update snap name to `rt-tests`
- Update snap licenses to match deb package licenses `GPL-2.0-or-later` AND `LGPL-2.1-or-later`